### PR TITLE
Add code of conduct and tweak CSS

### DIFF
--- a/CSS/main.css
+++ b/CSS/main.css
@@ -1,8 +1,16 @@
+html {
+  min-height: 100%;
+  display: flex;
+}
+
 body {
   margin:0;padding:0;
   background: white;
   max-width: 100%;
   font-family: Helvetica,sans-serif;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
 }
 
 h1 {
@@ -17,10 +25,6 @@ h2, h3, h4, h5, h6 {
 }
 h2 { font-size: 1.3rem;}
 h3 { font-size: 1.1rem;}
-ul, ul li {
-  display: block;
-  margin: 0; padding: 0;
-}
 
 a, a:visited, a:hover, a:focus {
   color: #4184F3;
@@ -62,6 +66,7 @@ header a:hover, header a:focus {
 /*** main ***/
 main {
   display: flex;
+  flex-grow: 1;
   flex-flow: column;
   background: white;
   color: black;

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -1,0 +1,368 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>W3C Immersive Web Working Group</title>
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="viewport" content="width=device-width, initial-scale=1, initial-scale = 1.0, shrink-to-fit=no">
+    <base href="https://immersive-web.github.io/homepage/">
+    <link rel="stylesheet" href="CSS/main.css">
+    <meta name="application-name" content="ImmersiveWeb @W3C" />
+    <meta name="screen-orientation" content="portrait" />
+    <meta name="full-screen" content="yes" />
+    <meta name="description" content="The Immersive Web." />
+  </head>
+  <body>
+    <header>
+      <nav>
+        <ul>
+          <li><a href="https://www.w3.org/standards/">Standards</a></li>
+          <li><a href="https://www.w3.org/participate/">Participate</a></li>
+          <li><a href="https://www.w3.org/Consortium/membership">Membership</a></li>
+          <li><a href="https://www.w3.org/Consortium/">About W3C</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main>
+      <nav>
+        <h3>Getting involved</h3>
+        <ul>
+          <li><a href="https://github.com/immersive-web">Github</a></li>
+          <li><a href="https://lists.w3.org/Archives/Public/public-immersive-web-wg/">Mailing list</a></li>
+          <li><a href="code-of-conduct.html">Code of Conduct</a></li>
+        </ul>
+        <h3>Drafts and Notes</h3>
+        <ul>
+          <li><a href="https://immersive-web.github.io/webxr/">The Web XR Device API</a></li>
+        </ul>
+        <h3>Group details</h3>
+        <ul>
+          <li><a href="https://www.w3.org/2018/09/immersive-web-wg-charter">Our Charter</a></li>
+          <li><a href="https://www.w3.org/2004/01/pp-impl/109735/join">How to Join</a></li>
+          <li><a href="https://www.w3.org/2000/09/dbwg/details?group=109735&amp;order=org&amp;public=1">Participants</a></li>
+          <li><a href="https://www.w3.org/2004/01/pp-impl/109735/status">Royalty-free Patent Policy</a></li>
+          <li><a href="https://www.w3.org/wiki/Immersive-Web/">WIKI page</a></li>
+        </ul>
+      </nav>
+
+    <section id='content'>
+      <h1 id="immersivewebworkinggroupcodeofconduct">Immersive Web Working Group Code of Conduct</h1>
+
+      <p>The goal of this code of conduct is to ensure transparency in moderation of the working group and to ensure that the
+        working group is an environment where everyone can participate without fear of harassment. This Code of Conduct applies
+        to all Working Group related environments including:</p>
+
+      <ul>
+        <li>Text based communications, emails, mailing lists, instant messaging and chat rooms.</li>
+
+        <li>'Virtual' meetings whether over video chat or in XR environments.</li>
+
+        <li>Face to Face meetings.</li>
+
+        <li>This includes environments which are "off the record" but are relating to Working Group procedure.</li>
+      </ul>
+
+      <p>The foundation of this Code of Conduct is the
+        <a href="https://www.w3.org/Consortium/cepc/">W3C Code of Ethics and Professional Conduct</a>, which is extended by this document to be more precise and specific
+        to the Immersive Web Working Group.</p>
+
+      <h2 id="ifyouseeacodeofconductviolation">
+        <strong>If you see a Code of Conduct Violation</strong>
+      </h2>
+
+      <ol>
+        <li>If you are comfortable doing so, let the person know that what they did is not appropriate and ask them to stop and/or
+          edit their message(s). That person should immediately stop the behaviour and correct the issue.</li>
+
+        <li>If this doesn’t happen, or if you’re uncomfortable speaking up, report it to an appropriate person, see below.</li>
+      </ol>
+
+      <p>They will ask the offending member to correct themselves, the offending party may also be asked by a chair to take
+        a break from the discussion to cool down. In the case of serious or intentional repeated infractions we will assist
+        in raising the case to a W3C Ombud — inline with the:</p>
+
+      <p>
+        <a href="https://www.w3.org/Consortium/pwe/#Procedures">W3C Positive Work Environment procedures.</a>
+      </p>
+
+      <h2 id="reporting">
+        <strong>Reporting</strong>
+      </h2>
+
+      <p>Violations of the code of conduct should be reported to one of the co-chairs of the group, or one of the designated
+        group members:</p>
+
+      <ul>
+        <li>Ada Rose Cannon (ada@ada.is, ada.cannon@samsung.com)</li>
+
+        <li>Chris Wilson (cwilso@google.com)</li>
+      </ul>
+
+      <p>Preferably reports should be made via real time communication, face to face, or instant messaging to allow the issues
+        to be resolved in a timely manner, but issues should still be reported even if it is at a later date.</p>
+
+      <p>
+        <strong>If you mess up</strong>
+      </p>
+
+      <p>As we engage in diverse communities we may accidentally cause offence, whether through using unknowingly offensive
+        terminology or through missing social cues.</p>
+
+      <p>If you realise (or our told) that you have offended someone then take the appropriate steps:</p>
+
+      <ol>
+        <li>Accept you made a mistake</li>
+
+        <li>Briefly apologise. Don't try to explain yourself or minimise the issue.</li>
+
+        <li>If possible, edit your message, restate your communication in a better way or withdraw your statement. Publicly revising
+          your statement helps define the culture for others.</li>
+      </ol>
+
+      <p>
+        <em>Alice:</em> “Yeah I used X and it was really crazy!”
+        <em>Eve:</em> “Hey, could you not use that word? What about ‘ridiculous’ instead?”
+        <em>Alice:</em> “oh sorry, sure.” -> edits old message to say “Yeah I used X and it was really confusing!”</p>
+
+      <p>This will allow conversation to quickly continue without any need of further action or escalating the situation.</p>
+
+      <p>If you don't understand what you did wrong assume the the hurt party has good cause and accept it. We can't know everyone's
+        background, and should do our best to avoid harm. You are welcome to discuss it with us later.</p>
+
+      <h2 id="unacceptablebehaviour">
+        <strong>Unacceptable behaviour</strong>
+      </h2>
+
+      <p>To help participants understand behaviors that are unacceptable or run counter to our culture, we’ve listed below actions
+        that violate our Code of Conduct policy.</p>
+
+      <p>This list does not cover every case. Each person you interact with is unique, and as a result can define a line of
+        unacceptable behavior that’s unique to them. Ensuring that your behavior does not have a negative impact is your
+        responsibility.</p>
+
+      <ul>
+        <li>Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness,
+          neurotype, physical appearance, body, age, race, socio-economic status, ethnicity, nationality, language, or religion</li>
+
+        <li>Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health,
+          parenting, drugs, and employment</li>
+
+        <li>Deliberate misgendering or use of ‘dead’ or rejected names</li>
+
+        <li>Gratuitous or off-topic sexual images or behaviour in spaces where they’re not appropriate</li>
+
+        <li>Physical contact and simulated physical contact (e.g., textual descriptions like “hug” or “backrub”) without consent
+          or after a request to stop</li>
+
+        <li>Threats of violence</li>
+
+        <li>Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm</li>
+
+        <li>Deliberate intimidation</li>
+
+        <li>Stalking or following</li>
+
+        <li>Harassing photography or recording, including logging online activity for harassment purposes</li>
+
+        <li>Sustained disruption of discussion</li>
+
+        <li>Unwelcome sexual attention</li>
+
+        <li>Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others</li>
+
+        <li>Continued one-on-one communication after requests to cease</li>
+
+        <li>Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect other
+          community members or other vulnerable people from intentional abuse</li>
+
+        <li>Publication of non-harassing private communication without consent by the involved parties</li>
+
+        <li>Use of "dog whistles", coded language used to rally support for hate groups and to intmidate vulnerable groups.</li>
+
+        <li>Microaggressions, which are small comments or questions, either intentional or unintentional, that marginalize people
+          by communicating hostile, derogatory, or negative beliefs. Examples include
+
+
+          <ul>
+            <li>Patronizing language or behaviour
+
+
+              <ul>
+                <li>Pedantic corrections that don’t contribute to the conversation (For example: “Well actually…”)</li>
+
+                <li>Assuming without asking that particular people or groups need concepts defined or explained to them. (It’s
+                  great to be sensitive to the fact that people may not be familiar with technical terms you use every day,
+                  but assuming that people are uninformed can come across as patronizing.)</li>
+
+                <li>Assuming that particular groups of people are technically unskilled (“So easy your grandmother could do it.”)</li>
+              </ul>
+            </li>
+
+            <li>Repeatedly interrupting or talking over someone else</li>
+
+            <li>Feigning surprise at someone’s lack of knowledge or awareness about a topic</li>
+
+            <li>The use of racially charged language to describe an individual or thing (such as “thug” or “ghetto”)</li>
+
+            <li>Referring to an individual in a way that demeans or challenges the validity of their racial identity</li>
+
+            <li>Mocking someone’s real or perceived accent or first language</li>
+          </ul>
+        </li>
+
+        <li>Retaliating against anyone who files a complaint that someone has violated this code of conduct.</li>
+      </ul>
+
+      <p>The enforcers of this Code of Conduct should prioritise marginalized people’s safety over privileged people’s comfort,
+        and reserve the right not to act on complaints regarding:</p>
+
+      <ul>
+        <li>‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and ‘cisphobia’</li>
+
+        <li>Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”</li>
+
+        <li>Communicating in a ‘tone’ you don’t find congenial</li>
+
+        <li>Criticizing racist, sexist, cissexist, or otherwise oppressive behaviour or assumptions</li>
+      </ul>
+
+      <h1 id="expectedbehavior">
+        <strong>Expected Behavior</strong>
+      </h1>
+
+      <p>The following behaviors are expected of all participants in the Working Group:</p>
+
+      <h2 id="berespectful">
+        <strong>Be Respectful</strong>
+      </h2>
+
+      <p>Value each other’s ideas, styles and viewpoints. We may not always agree, but disagreement is no excuse for poor manners.
+        Be open to different possibilities and to being wrong. Be kind in all interactions and communications, especially
+        when debating the merits of different options. Be aware of your impact and how intense interactions may be affecting
+        people.</p>
+
+      <p>Be direct, constructive and positive. Take responsibility for your impact and your mistakes – if someone says they
+        have been harmed through your words or actions, listen carefully, apologize sincerely, and correct the behaviour
+        going forward.</p>
+
+      <h2 id="bedirectbutprofessional">
+        <strong>Be Direct but Professional</strong>
+      </h2>
+
+      <p>We are likely to have some discussions about if and when criticism is respectful and when it’s not. We
+        <em>must</em> be able to speak directly when we disagree and when we think we need to improve. We cannot withhold hard
+        truths. Doing so respectfully is hard, doing so when others don’t seem to be listening is harder, and hearing such
+        comments when one is the recipient can be even harder still. We need to be honest and direct, as well as respectful.</p>
+
+      <h2 id="beinclusive">
+        <strong>Be Inclusive</strong>
+      </h2>
+
+      <p>Seek diverse perspectives. Diversity of views and of people on teams powers innovation, even if it is not always comfortable.
+        Encourage all voices. Help new perspectives be heard and listen actively. If you find yourself dominating a discussion,
+        it is especially important to step back and encourage other voices to join in. Be aware of how much time is taken
+        up by dominant members of the group. Provide alternative ways to contribute or participate when possible.</p>
+
+      <p>Be inclusive of everyone in an interaction, respecting and facilitating people’s participation whether they are:</p>
+
+      <ul>
+        <li>Remote (on video or phone)</li>
+
+        <li>Not native language speakers</li>
+
+        <li>Coming from a different culture</li>
+
+        <li>Using pronouns other than “he” or “she”</li>
+
+        <li>Living in a different time zone</li>
+
+        <li>Facing other challenges to participate</li>
+      </ul>
+
+      <p>Think about how you might facilitate alternative ways to contribute or participate. If you find yourself dominating
+        a discussion, step back.</p>
+
+      <p>Make way for other voices and listen actively to them.</p>
+
+      <h2 id="understanddifferentperspectives">
+        <strong>Understand Different Perspectives</strong>
+      </h2>
+
+      <p>Our goal should not be to “win” every disagreement or argument. A more productive goal is to be open to ideas that
+        make our own ideas better. Strive to be an example for inclusive thinking. “Winning” is when different perspectives
+        make our work richer and stronger.</p>
+
+      <h2 id="appreciateandaccommodateoursimilaritiesanddifferences">
+        <strong>Appreciate and Accommodate Our Similarities and Differences</strong>
+      </h2>
+
+      <p>We all come from many cultures and backgrounds. Cultural differences can encompass everything from official religious
+        observances to personal habits to clothing. Be respectful of people with different cultural practices, attitudes
+        and beliefs. Work to eliminate your own biases, prejudices and discriminatory practices. Think of others’ needs from
+        their point of view. Use preferred names, titles (including pronouns) and the appropriate tone of voice. Respect
+        people’s right to privacy and confidentiality. Be open to learning from and educating others as well as educating
+        yourself; it is unrealistic to expect to know the cultural practices of every ethnic and cultural group, but everyone
+        needs to recognize one’s native culture is only part of positive interactions.</p>
+
+      <h2 id="leadbyexample">
+        <strong>Lead by Example</strong>
+      </h2>
+
+      <p>By matching your actions with your words, you become a person others want to follow. Your actions influence others
+        to behave and respond in ways that are appropriate for good communication. Design your community and your work for
+        inclusion. Hold yourself and others accountable for inclusive behaviours.</p>
+
+      <h2 id="attribution">Attribution</h2>
+
+      <p>This Code of Conduct is CC By Attribution, based off the following codes of conduct:</p>
+
+      <ul>
+        <li>The WeAllJS Code of Conduct:</li>
+      </ul>
+
+      <p>
+        <a href="https://wealljs.org/code-of-conduct">Code of Conduct - WeAllJS</a>
+      </p>
+
+      <ul>
+        <li>The XOXO code of conduct:</li>
+      </ul>
+
+      <p>
+        <a href="https://github.com/xoxo/conduct">xoxo/conduct</a>
+      </p>
+
+      <ul>
+        <li>The code of conduct from slack.design.systems</li>
+      </ul>
+
+      <p>
+        <a href="http://slack.design.systems">Design Systems Slack</a>
+      </p>
+
+      <ul>
+        <li>The Expected Behaviour Section is adopted from Mozilla's Participation Guidelines.</li>
+      </ul>
+
+      <p>
+        <a href="https://www.mozilla.org/en-US/about/governance/policies/participation/">Community Participation Guidelines</a>
+      </p>
+    </section>
+
+  </main>
+
+  <footer>
+    <address>
+      <a href="https://github.com/immersive-web/">We are on GitHub</a>
+    </address>
+    <p id="copyright">
+      <a href="https://www.w3.org/">W3C</a> -
+      <a href="https://www.w3.org/Consortium/Legal/privacy-statement">Privacy</a> -
+      <a href='http://www.w3.org/Consortium/Legal/ipr-notice'>Terms</a>
+    </p>
+  </footer>
+
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
     <title>W3C Immersive Web Working Group</title>
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="viewport" content="width=device-width, initial-scale=1, initial-scale = 1.0, shrink-to-fit=no">
-    <link rel="stylesheet" href="https://www.w3.org/webperf/css/main.css">
+    <base href="https://immersive-web.github.io/homepage/">
+    <link rel="stylesheet" href="CSS/main.css">
     <meta name="application-name" content="ImmersiveWeb @W3C" />
     <meta name="screen-orientation" content="portrait" />
     <meta name="full-screen" content="yes" />
@@ -29,7 +30,7 @@
         <ul>
           <li><a href="https://github.com/immersive-web">Github</a></li>
           <li><a href="https://lists.w3.org/Archives/Public/public-immersive-web-wg/">Mailing list</a></li>
-          <li><a href="https://www.w3.org/Consortium/cepc/">Code of Conduct</a></li>
+          <li><a href="code-of-conduct.html">Code of Conduct</a></li>
         </ul>
         <h3>Drafts and Notes</h3>
         <ul>


### PR DESCRIPTION
Adds the Code of Conduct.

Uses the CSS file from the project rather than the webperf one.

For some reason the CSS file is not available via the w3.org domain so use the `<base>` tag to make sure relative resources get mapped to the github pages version.