### PR TITLE
added a link to list_spec page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The Immersive Web Working Group produces the WebXR Device API specification.
 * [WebXR Layers API](https://github.com/immersive-web/layers)
 * [WebXR Hand Input](https://github.com/immersive-web/webxr-hand-input)
 
+See also [list of all specifications in Working/Community Group with detailed statuses](https://www.w3.org/immersive-web/list_spec.html). 
+
 ## Contributing to the Immersive Web Repository
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/index.html
+++ b/index.html
@@ -75,6 +75,9 @@
             <a href="https://immersive-web.github.io/lighting-estimation/">Editor's draft</a>;
             and <a href="https://github.com/immersive-web/lighting-estimation/issues">github issues</a>
           </li>
+          <li>
+            <a href="https://www.w3.org/immersive-web/list_spec.html">List of all specifications with detailed statuses</a>
+          </li>
         </ul>
         <h3>Group details</h3>
         <ul>


### PR DESCRIPTION
Added as new link, not to delete current list of specifications' links.
For WG top page (`index.html`), we may replace all list with a link, like `<h3><a href="xxx">Drafts and Notes</a></h3>`, but it might be better to keep a list at the top page??