### PR TITLE
following some W3C system URLs changed (e.g. pp-impl to wg/XXX)

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,9 +79,9 @@
         <h3>Group details</h3>
         <ul>
           <li><a href="https://www.w3.org/2020/05/immersive-Web-wg-charter.html">Our Charter</a></li>
-          <li><a href="https://www.w3.org/2004/01/pp-impl/109735/join">How to Join</a></li>
-          <li><a href="https://www.w3.org/2000/09/dbwg/details?group=109735&amp;order=org&amp;public=1">Participants</a></li>
-          <li><a href="https://www.w3.org/2004/01/pp-impl/109735/status">Royalty-free Patent Policy</a></li>
+          <li><a href="https://www.w3.org/groups/wg/immersive-web/join">How to Join</a></li>
+          <li><a href="https://www.w3.org/groups/wg/immersive-web/participants">Participants</a></li>
+          <li><a href="https://www.w3.org/groups/wg/immersive-web/ipr">Royalty-free Patent Policy</a></li>
           <li><a href="https://www.w3.org/wiki/Immersive-Web/">WIKI page</a></li>
         </ul>
       </nav>
@@ -163,7 +163,7 @@
             </ul>
             <h3>Face-to-Face follow ups</h3>
             <ul>
-              <li><a href="https://github.com/immersive-web/administrivia/blob/master/newsletter/2919-01-28-Face-to-face-follow-up.md">January 2019 F2F Follow Up</a></li>
+              <li><a href="https://github.com/immersive-web/administrivia/blob/main/newsletter/2019-01-28-Face-to-face-follow-up.md">January 2019 F2F Follow Up</a></li>
             </ul>
           </article>
 


### PR DESCRIPTION
Recent system upgrade at w3.org site, some URLs changed for group status.
This fixes these redirects.