### PR TITLE
updated upcoming f2f

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,13 +109,24 @@
             <h3>Upcoming</h3>
             <ul>
               <li>
-                24th to 25th April 2023 (hybrid meeting) at <a href="https://en.wikipedia.org/wiki/Apple_Campus">Apple's Infinite Loop Campus</a> in Cupertino California. 
-                (<a href="https://lists.w3.org/Archives/Public/public-immersive-web-wg/2023Jan/0006.html">Announcement and Registration</a>)
-                [<a href="https://github.com/immersive-web/administrivia/blob/main/F2F-April-2023/schedule.md">agenda</a>]
+                11th, 12th and 15th September 2023 (hybrid meeting) at <a href="https://www.w3.org/2023/09/TPAC/Overview.html">TPAC 2023</a>
+                (calendar:
+                  <a href="https://www.w3.org/events/meetings/f1dd67cb-9322-472e-92d4-a34a2f4bf2d6/">11th</a>,
+                  <a href="https://www.w3.org/events/meetings/543e6388-05f4-4334-bd4d-4839ec021fc5/">12th</a>,
+                  <a href="https://www.w3.org/events/meetings/7e00b17e-b4ef-471b-96c1-21a2c9d77c92/">15th</a>)
               </li>
             </ul>
             <h3>Past FTF meetings</h3>
             <ul>
+              <li>
+                24th to 25th April 2023 (hybrid meeting) at <a href="https://en.wikipedia.org/wiki/Apple_Campus">Apple's Infinite Loop Campus</a> in Cupertino California. 
+                (<a href="https://lists.w3.org/Archives/Public/public-immersive-web-wg/2023Jan/0006.html">Announcement and Registration</a>)
+                [<a href="https://github.com/immersive-web/administrivia/blob/main/F2F-April-2023/schedule.md">agenda</a>]
+                [Minutes:
+                  <a href="https://www.w3.org/2023/04/24-immersive-web-minutes.html">24th April (day 1)</a>,
+                  <a href="https://www.w3.org/2023/04/25-immersive-web-minutes.html">25th April (day 2)</a>
+                ]
+              </li>
               <li>12th to 16th September 2022 (hybrid meetings) at <a href="https://www.w3.org/2022/09/TPAC/">TPAC 2022</a>
                 [<a href="https://github.com/immersive-web/administrivia/tree/main/TPAC-2022">agenda</a>] 
                 [Minutes:


### PR DESCRIPTION
Moved April f2f as past, and listed TPAC2023 as upcoming.

Several another points
- do we need/want to keep [code-of-conduct](https://github.com/immersive-web/homepage/blob/main/code-of-conduct.html) in this repository? (we migrated all of our custom ones into W3C wide one)
- do we want to keep [immersive-web wiki](https://www.w3.org/wiki/Immersive-Web/) as listed (bottom of Group details)? - there seems no edit after creation...