### PR TITLE
added info for 2026May f2f

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
                   ;
                   <a href="https://docs.google.com/forms/d/e/1FAIpQLSffIqTK45GXDKFfYH6g0XhzmV4L2efPHElpWsJNz-YDpFhV_A/viewform">RSVP</a>
                 )
-                [agenda]
+                [<a href="https://github.com/immersive-web/administrivia/blob/main/F2F-May-2026/schedule.md">agenda</a>]
               </li>
             </ul>
             <h3>Past FTF meetings</h3>

--- a/index.html
+++ b/index.html
@@ -108,7 +108,21 @@
             <h2>Face-to-face meetings</h2>
             <h3>Upcoming</h3>
             <ul>
-              <li>No group meeting is planned at <a href="https://www.w3.org/events/tpac/2025/tpac-2025/">TPAC 2025</a>.</li>
+              <li>19 th and 20th May 2026 (hybrid meeting) at Apple New York City 14 (11 Penn Plaza, New York, NY 10001, USA)
+                (
+                  <a href="https://lists.w3.org/Archives/Public/public-immersive-web-wg/2026Mar/0002.html">annoucement</a>
+                  ;
+                  calendar:
+                    <a href="https://www.w3.org/events/meetings/92949730-6e1a-4a3b-9da4-9e1157b72cbc/">19th</a>,
+                    <a href="https://www.w3.org/events/meetings/7178d704-872e-482c-89b6-12987481798e/">20th</a>
+                  ;
+                  <a href="https://docs.google.com/forms/d/e/1FAIpQLSffIqTK45GXDKFfYH6g0XhzmV4L2efPHElpWsJNz-YDpFhV_A/viewform">RSVP</a>
+                )
+                [agenda]
+              </li>
+            </ul>
+            <h3>Past FTF meetings</h3>
+            <ul>
               <li>20th and 21st November 2025 (hybrid meeting) at MPK classic campus, Meta (<a href="https://maps.app.goo.gl/4gA3KcL2TjN6FVKX7">Lobby 15, 10 Hacker Way, Menlo Park, CA 94025, USA</a>; please check email on any last minute changes)
                 (calendar: 
                   <a href="https://www.w3.org/events/meetings/aae0c507-186d-4a3e-a4cb-5722437a9a33/">20th</a>,
@@ -117,10 +131,12 @@
                   <a href="https://docs.google.com/forms/d/e/1FAIpQLSdknoSYDZhA-pU6C16JvFmCVdo8-hXtyIPW3ZpwNlw8k6lgpA/viewform?usp=header%EF%BF%BC">RSVP</a>
                 )
                 [<a href="https://github.com/immersive-web/administrivia/blob/main/F2F-November-2025/schedule.md">agenda</a>]
+                [Minutes:
+                  <a href="https://www.w3.org/2025/11/20-immersive-web-minutes.html">20th (day 1)</a>,
+                  <a href="https://www.w3.org/2025/11/21-immersive-web-minutes.html">21st (day 2)</a>
+                ]
               </li>
-            </ul>
-            <h3>Past FTF meetings</h3>
-            <ul>
+              <li>No group meeting is planned at <a href="https://www.w3.org/events/tpac/2025/tpac-2025/">TPAC 2025</a>.</li>
               <li>18th and 19th March 2025 (hybrid meeting) at Chrome building, Google Mountain View Campus (<a href="https://maps.app.goo.gl/6hqKa3tgyRSTM49F8">900 Alta Ave, Mountain View, CA 94043</a>; please check email on any last minute changes)
                 (calendar:
                   <a href="https://www.w3.org/events/meetings/487432a3-839b-4be0-93c3-c40d9fb25374/20250318T110000/">18th</a>,


### PR DESCRIPTION
- moved 2025 Nov to past (minutes cleaned up with added topic: lines)
- added two events for 2026 May f2f into W3C calendar
- assigned zoom call for 2026 May f2f